### PR TITLE
set ott route to not be strict slash

### DIFF
--- a/data_logger_server/blueprints/ott.py
+++ b/data_logger_server/blueprints/ott.py
@@ -138,7 +138,7 @@ def ott_response(root_dir: pathlib.Path):
     return flask.Response(body, mimetype='application/xml')
 
 
-@blueprint.route('/ott/', methods=['POST'])
+@blueprint.route('/ott', strict_slashes=False, methods=['POST'])
 def ott():
     """
     Route request to the appropriate function


### PR DESCRIPTION
On the weather stations there has been some confusion as whether they should include a `/` on the route after ott or not. Current stations in the field now have both rules so this PR allowes both routes to work.

Tested on a station in the lab.

closing #7 